### PR TITLE
Flake templates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,16 +51,15 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1702964150,
-        "narHash": "sha256-cAl4ZDFY4SW3Ly2aRdBd05rqkFyPuQUXhgVGttfzSDU=",
-        "owner": "shivaraj-bh",
+        "lastModified": 1703012200,
+        "narHash": "sha256-iGSNUktkmUmrgLKwnAwGuwlnResHRvLZKqZSkncBqj0=",
+        "owner": "srid",
         "repo": "emanote",
-        "rev": "a52d953858dd51152cfea5912959b3fd04ccbc14",
+        "rev": "48eabd0a508e7991d3f36fb08e968a6b5585435e",
         "type": "github"
       },
       "original": {
-        "owner": "shivaraj-bh",
-        "ref": "update-nixpkgs",
+        "owner": "srid",
         "repo": "emanote",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1703012200,
-        "narHash": "sha256-iGSNUktkmUmrgLKwnAwGuwlnResHRvLZKqZSkncBqj0=",
+        "lastModified": 1703792616,
+        "narHash": "sha256-mhQ/gvjzBk9efVXHPp4EPmLw2ww7kdwieAfjemT/z3Q=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "48eabd0a508e7991d3f36fb08e968a6b5585435e",
+        "rev": "486273f3d40c1b01b820bafdfa4c9f2020b98306",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1702961700,
-        "narHash": "sha256-jC/SfcrSSuuCDSOEuxWZ9QQX9ujmhyqMMa6+z9CXhPk=",
+        "lastModified": 1702964150,
+        "narHash": "sha256-cAl4ZDFY4SW3Ly2aRdBd05rqkFyPuQUXhgVGttfzSDU=",
         "owner": "shivaraj-bh",
         "repo": "emanote",
-        "rev": "f205813a9c8bb940dc799e82d4a74e822b5a7d07",
+        "rev": "a52d953858dd51152cfea5912959b3fd04ccbc14",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,7 @@
 {
   "nodes": {
-    "check-flake": {
-      "locked": {
-        "lastModified": 1662502605,
-        "narHash": "sha256-jAT55UhabAxLAVGanxjnNdzH2/oX2ZjLsL4i2jPIP+g=",
-        "owner": "srid",
-        "repo": "check-flake",
-        "rev": "48a17393ed4fcd523399d6602c283775b5127295",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "check-flake",
-        "type": "github"
-      }
-    },
     "ema": {
       "inputs": {
-        "check-flake": "check-flake",
         "flake-parts": [
           "emanote",
           "flake-parts"
@@ -40,15 +24,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1691619338,
-        "narHash": "sha256-Nxx184m3caxW5z/EMjVZyuTGi8IPH1qTwMAzJBblWUA=",
+        "lastModified": 1702334080,
+        "narHash": "sha256-zrtzyLrSORxtocLMji5U9p4pDicMulOqgsuiB4LCu1o=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "de01c397e050434f41fc9a12fc40de264dc62c21",
+        "rev": "33f4cf31ace7e612e78ad25f5fc45089745ab644",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "no-ws",
         "repo": "ema",
         "type": "github"
       }
@@ -58,7 +43,6 @@
         "ema": "ema",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
-        "flake-schemas": "flake-schemas",
         "haskell-flake": "haskell-flake",
         "heist-extra": "heist-extra",
         "nixpkgs": "nixpkgs",
@@ -67,15 +51,16 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1701214770,
-        "narHash": "sha256-5WEoJYPRYD9N0qQ23nao6irzKg+SNH4DY3lTHHdBmSU=",
-        "owner": "srid",
+        "lastModified": 1702961700,
+        "narHash": "sha256-jC/SfcrSSuuCDSOEuxWZ9QQX9ujmhyqMMa6+z9CXhPk=",
+        "owner": "shivaraj-bh",
         "repo": "emanote",
-        "rev": "ea2dca29a92430572048eb5ad5f018b0e66c42bc",
+        "rev": "f205813a9c8bb940dc799e82d4a74e822b5a7d07",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
+        "owner": "shivaraj-bh",
+        "ref": "update-nixpkgs",
         "repo": "emanote",
         "type": "github"
       }
@@ -113,21 +98,6 @@
         "type": "github"
       }
     },
-    "flake-schemas": {
-      "locked": {
-        "lastModified": 1693615523,
-        "narHash": "sha256-LeyH24etXCxNJviWptyLy2DPT9xt+oOs/zE66To1iPY=",
-        "owner": "DeterminateSystems",
-        "repo": "flake-schemas",
-        "rev": "8940e872c4f8c7cd7d0a1ec169fa0a24697b1f1c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DeterminateSystems",
-        "repo": "flake-schemas",
-        "type": "github"
-      }
-    },
     "haskell-flake": {
       "locked": {
         "lastModified": 1692741689,
@@ -161,11 +131,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693626178,
-        "narHash": "sha256-Rpiy6lIOu4zny8tfGuIeN1ji9eSz9nPmm9yBhh/4IOM=",
+        "lastModified": 1702900294,
+        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfb7dfec93f3b5d7274db109f2990bc889861caf",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,6 +41,7 @@
     "emanote": {
       "inputs": {
         "ema": "ema",
+        "emanote-template": [],
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "haskell-flake": "haskell-flake",
@@ -51,11 +52,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1703792616,
-        "narHash": "sha256-mhQ/gvjzBk9efVXHPp4EPmLw2ww7kdwieAfjemT/z3Q=",
+        "lastModified": 1703878530,
+        "narHash": "sha256-s3jjsoBJynDcNrfQSNPApdXt9zyNL2Vfp9vb9T/HA9s=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "486273f3d40c1b01b820bafdfa4c9f2020b98306",
+        "rev": "4ebfa67f3d5ab795fbe04f663f767708527d4980",
         "type": "github"
       },
       "original": {
@@ -198,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693468138,
-        "narHash": "sha256-DddblCahuTW8K0ncPOheTlG3igE8b15LJjafF1PWhOo=",
+        "lastModified": 1702979157,
+        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6930a5ba0a722385baf273885a03f561dcb1af67",
+        "rev": "2961375283668d867e64129c22af532de8e77734",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   };
 
   inputs = {
-    emanote.url = "github:shivaraj-bh/emanote/update-nixpkgs";
+    emanote.url = "github:srid/emanote";
     nixpkgs.follows = "emanote/nixpkgs";
     flake-parts.follows = "emanote/flake-parts";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   inputs = {
     emanote.url = "github:srid/emanote";
+    emanote.inputs.emanote-template.follows = "";
     nixpkgs.follows = "emanote/nixpkgs";
     flake-parts.follows = "emanote/flake-parts";
   };
@@ -32,26 +33,6 @@
           ];
         };
         formatter = pkgs.nixpkgs-fmt;
-      };
-      # NOTE: The `flake.templates` attribute is only needed if in `emanote-template` repository.
-      flake.templates = {
-        default = {
-          description = "A simple flake.nix template for emanote";
-          path = builtins.path { path = self; filter = path: _: baseNameOf path == "flake.nix"; };
-        };
-        example = let fs = inputs.nixpkgs.lib.fileset; in {
-          description = "An example emanote site with VSCode integration and Github actions workflow";
-          path = builtins.toString (fs.toSource {
-            root = ./.;
-            fileset = fs.unions [
-              ./flake.nix
-              ./index.yaml
-              ./index.md
-              ./.vscode
-              ./.github
-            ];
-          });
-        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   };
 
   inputs = {
-    emanote.url = "github:srid/emanote";
+    emanote.url = "github:shivaraj-bh/emanote/update-nixpkgs";
     nixpkgs.follows = "emanote/nixpkgs";
     flake-parts.follows = "emanote/flake-parts";
   };
@@ -32,6 +32,26 @@
           ];
         };
         formatter = pkgs.nixpkgs-fmt;
+      };
+      # NOTE: The `flake.templates` attribute is only needed if in `emanote-template` repository.
+      flake.templates = {
+        default = {
+          description = "A simple flake.nix template for emanote";
+          path = builtins.path { path = self; filter = path: _: baseNameOf path == "flake.nix"; };
+        };
+        example = let fs = inputs.nixpkgs.lib.fileset; in {
+          description = "An example emanote site with VSCode integration and Github actions workflow";
+          path = builtins.toString (fs.toSource {
+            root = ./.;
+            fileset = fs.unions [
+              ./flake.nix
+              ./index.yaml
+              ./index.md
+              ./.vscode
+              ./.github
+            ];
+          });
+        };
       };
     };
 }


### PR DESCRIPTION
Resolves https://github.com/srid/emanote/issues/421

Try the `example` template (which includes `.vscode` and `.github`):

```bash
mkdir test-emanote-template
cd test-emanote-template
nix flake init -t github:shivaraj-bh/emanote-template/flake-templates#example
```


TODO
- [x] Update `inputs.emanote.url` to upstream after: https://github.com/srid/emanote/pull/481
  **Reason:**
  The current `nixpkgs` doesn't include `lib.fileset` 